### PR TITLE
Added Path for backround image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Copy and replace the contents of the `profile` directory into the Windows 
 Terminal application data folder.
 
+Define the backround image path in settings.json
+something like 
+```
+Users/<yourUserName>/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/miku.png
+```
+
 If you are using the git bash profile please make sure that the profile's 
 `commandLine` field is set to the correct path.
 


### PR DESCRIPTION
Hey thanks for making this project it helped me add my own image to my temrinal.  

when I used it the path in the settings.json was now correct and gave me an error.  

putting this path whenver backround image was worked 
Users/<username>/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/miku.png

